### PR TITLE
send updated and added init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Optimus Prime
 
-A CLI tool for zipping directories and sending them to a server.
+A CLI tool for zipping directories and sending them to a server, particularly designed for competitions and submissions.
 
 ## Features
 
+- Config-driven workflow with YAML configuration file
 - Recursively zip the current directory and all subdirectories
 - Send the zip file to a server via HTTPS
 - Authentication with API key
+- Competition submission tracking
+- Interactive confirmation based on remaining attempts
+- Support for different packaging formats
 - Easy to install and use
 
 ## Installation
@@ -26,7 +30,7 @@ curl -sSL https://raw.githubusercontent.com/AutoScots/optimusprime/main/install.
 
 If you prefer to clone the repository first:
 
-```bash
+```bash 
 git clone --depth 1 https://github.com/AutoScots/optimusprime.git
 cd optimusprime
 ./install.sh
@@ -44,32 +48,96 @@ curl -sSL https://raw.githubusercontent.com/AutoScots/optimusprime/main/install-
 curl -sSL https://raw.githubusercontent.com/AutoScots/optimusprime/main/install-legacy.sh | bash
 ```
 
-## Usage
+## Configuration
 
-Set your API key as an environment variable:
+Optimus Prime uses a YAML configuration file (`submission.yml`) to manage submissions. This is the recommended way to provide API keys, competition IDs, and other settings.
+
+### Creating a Configuration File
+
+You can create a default configuration file:
 
 ```bash
-export OPTIMUS_API_KEY="your-api-key"
+optimus init
 ```
 
-Then use the `send` command to zip and send the current directory:
+This creates a `submission.yml` file in the current directory with default values. You can specify an API key and competition ID:
+
+```bash
+optimus init --api-key "your-api-key" --competition-id "comp-123"
+```
+
+### Example Configuration File
+
+```yaml
+# API key for authentication (required)
+api_key: "your-api-key-here"
+
+# Competition ID (optional, can be overridden via command line)
+competition_id: "competition-123"
+
+# Submission format: 'repo' or 'py' (optional, will check with server if not specified)
+format: "repo"
+
+# Server URL (optional, defaults to http://localhost:3000)
+server_url: "http://localhost:3000"
+
+# Compression level (0-9, optional, default is 6)
+compression_level: 6
+
+# Excluded directories/files (optional, adds to default exclusions)
+exclude:
+  - ".git"
+  - ".DS_Store"
+  - "node_modules"
+  - "target"
+  - ".env"
+  - "venv"
+
+# User preferences (optional)
+preferences:
+  # Whether to auto-confirm submissions (optional, default is false)
+  auto_confirm: false
+  
+  # Whether to save submission history (optional, default is true)
+  save_history: true
+```
+
+## Usage
+
+### Basic Usage
+
+To submit the current directory using settings from `submission.yml`:
 
 ```bash
 optimus send
 ```
 
-### Options
+The tool will:
+1. Contact the server to determine the required format and remaining attempts
+2. Ask for confirmation to proceed (unless auto-confirm is enabled)
+3. Create a zip file according to the required format
+4. Send the zip file to the server
+5. Display the response from the server
 
-```
+### Command Line Options
+
+All configuration options can be overridden via command line:
+
+```bash
 optimus send --help
 ```
 
-- `--api-key <KEY>`: API key for authentication (can also be set via OPTIMUS_API_KEY env var)
-- `--server <URL>`: Base URL for the server (default: http://localhost:3000)
-- `--compression <LEVEL>`: Compression level (0-9, default: 6)
-- `--force-format <FORMAT>`: Skip server check and force a specific format (repo or py)
+Available options:
 
-### Formats
+- `--config <PATH>`: Path to the configuration file (default: `submission.yml`)
+- `--api-key <KEY>`: API key for authentication (overrides config file)
+- `--competition-id <ID>`: Competition ID (overrides config file)
+- `--server <URL>`: Base URL for the server (overrides config file)
+- `--compression <LEVEL>`: Compression level (0-9, overrides config file)
+- `--force-format <FORMAT>`: Skip server check and force a specific format (repo or py) 
+- `--auto-confirm`: Auto-confirm submission without prompting
+
+### Submission Formats
 
 The tool supports different packaging formats:
 
@@ -78,17 +146,32 @@ The tool supports different packaging formats:
 
 By default, the tool contacts the server's `/check` endpoint to determine which format to use.
 
-## Example
+## Examples
+
+### Initialize Configuration
 
 ```bash
-# Set your API key
-export OPTIMUS_API_KEY="your-api-key"
+# Create default configuration file
+optimus init
 
-# Zip and send the current directory to a custom server with maximum compression
-optimus send --server https://api.example.com --compression 9
+# Create configuration with API key and competition ID
+optimus init --api-key "your-api-key" --competition-id "comp-123"
+```
 
-# Force Python format without checking with the server
-optimus send --force-format py
+### Submit Directory
+
+```bash
+# Submit using configuration file
+optimus send
+
+# Override server URL
+optimus send --server "https://api.example.com"
+
+# Force Python format and auto-confirm
+optimus send --force-format py --auto-confirm
+
+# Submit to a specific competition
+optimus send --competition-id "special-competition-456"
 ```
 
 ## Server Example

--- a/install-legacy.sh
+++ b/install-legacy.sh
@@ -48,8 +48,9 @@ rm -rf "$TMP_DIR"
 if command -v optimus &> /dev/null; then
     echo -e "${GREEN}✅ Optimus has been successfully installed!${NC}"
     echo -e "${BLUE}You can now use 'optimus send' to zip and send your directories.${NC}"
-    echo -e "${BLUE}Don't forget to set your API key:${NC}"
-    echo -e "${GREEN}export OPTIMUS_API_KEY=\"your-api-key\"${NC}"
+    echo -e "${YELLOW}Note: This is a legacy version of Optimus. ${NC}"
+    echo -e "${BLUE}For the latest version with configuration support, please use:${NC}"
+    echo -e "${GREEN}curl -sSL https://raw.githubusercontent.com/AutoScots/optimusprime/main/install.sh | bash${NC}"
 else
     echo -e "${RED}❌ Installation failed. ${NC}"
     exit 1

--- a/install.sh
+++ b/install.sh
@@ -8,12 +8,12 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-echo -e "${BLUE}Installing Optimus Prime directly...${NC}"
+echo -e "${BLUE}Installing Optimus Prime...${NC}"
 
 # Check if git is installed
 if ! command -v git &> /dev/null; then
     echo -e "${YELLOW}Git is not installed. Installing it now...${NC}"
-
+    
     # Check the OS
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         # Linux - Try apt-get first (Debian/Ubuntu)
@@ -48,14 +48,14 @@ if ! command -v git &> /dev/null; then
         echo -e "${BLUE}Please install Git manually and try again.${NC}"
         exit 1
     fi
-
+    
     # Verify installation
     if ! command -v git &> /dev/null; then
         echo -e "${RED}Failed to install Git.${NC}"
         echo -e "${BLUE}Please install Git manually and try again.${NC}"
         exit 1
     fi
-
+    
     echo -e "${GREEN}Git has been successfully installed!${NC}"
 fi
 
@@ -96,6 +96,18 @@ echo -e "${BLUE}Cloning Optimus repository...${NC}"
 git clone --depth 1 https://github.com/AutoScots/optimusprime.git "$TMP_DIR/optimus"
 cd "$TMP_DIR/optimus/repo-zipper"
 
+# Fix the code issues
+echo -e "${BLUE}Fixing code issues...${NC}"
+
+# Use the updated Cargo.toml with the new dependencies
+# Update Cargo.toml if needed
+if ! grep -q "serde_yaml" Cargo.toml; then
+    echo -e "${BLUE}Adding required dependencies...${NC}"
+    cargo add serde_yaml --quiet
+    cargo add dialoguer --quiet 
+    cargo add dirs --quiet
+fi
+
 # Build and install
 echo -e "${BLUE}Building and installing Optimus...${NC}"
 cargo install --path .
@@ -108,12 +120,16 @@ rm -rf "$TMP_DIR"
 # Verify installation
 if command -v optimus &> /dev/null; then
     echo -e "${GREEN}✅ Optimus has been successfully installed!${NC}"
-    echo -e "${BLUE}You can now use 'optimus send' to zip and send your directories.${NC}"
-    echo -e "${YELLOW}Note: This is a legacy version of Optimus. ${NC}"
-    echo -e "${BLUE}For the latest version with configuration support, please use:${NC}"
-    echo -e "${GREEN}curl -sSL https://raw.githubusercontent.com/AutoScots/optimusprime/main/install.sh | bash${NC}"
+    echo -e "${BLUE}You can now use 'optimus' to zip and send your directories.${NC}"
+    echo -e "${BLUE}To get started, create a configuration file:${NC}"
+    echo -e "${GREEN}optimus init${NC}"
+    echo -e ""
+    echo -e "${BLUE}Then edit it to set your API key and preferences:${NC}"
+    echo -e "${GREEN}nano submission.yml${NC}"
+    echo -e ""
+    echo -e "${BLUE}Finally, send your directory:${NC}"
+    echo -e "${GREEN}optimus send${NC}"
 else
-    echo -e "${RED}❌ Installation failed. Please try installing manually with:${NC}"
-    echo -e "${GREEN}cd repo-zipper && cargo install --path .${NC}"
+    echo -e "${RED}❌ Installation failed. Please try installing manually with 'cargo install --git https://github.com/AutoScots/optimusprime.git --path repo-zipper'${NC}"
     exit 1
 fi

--- a/repo-zipper/Cargo.lock
+++ b/repo-zipper/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,10 +130,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -125,11 +157,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -138,6 +192,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -186,6 +250,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +285,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +382,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -242,6 +419,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -322,6 +509,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +577,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -591,6 +808,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +835,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +859,16 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -702,6 +948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +1013,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "optimus"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dialoguer",
+ "dirs",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +1080,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -809,12 +1112,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
-name = "repo-zipper"
-version = "0.1.0"
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "anyhow",
- "clap",
- "reqwest",
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -899,6 +1210,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1295,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1377,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1073,11 +1440,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -1159,6 +1565,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1581,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -1204,6 +1628,22 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1308,6 +1748,15 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1535,6 +1984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
 name = "zerovec"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,4 +2009,53 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/repo-zipper/Cargo.toml
+++ b/repo-zipper/Cargo.toml
@@ -20,3 +20,6 @@ zip = "0.6"
 walkdir = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
+dialoguer = "0.11"
+dirs = "5.0"

--- a/repo-zipper/src/main.rs
+++ b/repo-zipper/src/main.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use dialoguer::{Confirm, theme::ColorfulTheme};
 use reqwest::blocking::{Client, multipart};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -10,9 +11,56 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use walkdir::WalkDir;
 use zip::{write::FileOptions, ZipWriter};
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+struct SubmissionConfig {
+    // Required fields
+    api_key: String,
+    
+    // Optional fields
+    #[serde(default)]
+    competition_id: Option<String>,
+    
+    #[serde(default)]
+    format: Option<String>,
+    
+    #[serde(default = "default_server_url")]
+    server_url: String,
+    
+    #[serde(default = "default_compression_level")]
+    compression_level: u8,
+    
+    #[serde(default)]
+    exclude: Vec<String>,
+    
+    #[serde(default)]
+    preferences: Preferences,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+struct Preferences {
+    #[serde(default)]
+    auto_confirm: bool,
+    
+    #[serde(default = "default_true")]
+    save_history: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_server_url() -> String {
+    "http://localhost:3000".to_string()
+}
+
+fn default_compression_level() -> u8 {
+    6
+}
+
 #[derive(Deserialize, Debug)]
 struct CheckResponse {
     required_format: String,
+    remaining_attempts: i32,
     last_submission_by_user: Option<u64>,
 }
 
@@ -27,27 +75,125 @@ struct Cli {
 enum Commands {
     /// Zip the current directory and send it to the server
     Send {
-        /// API key for authentication
+        /// Path to the submission.yml config file
+        #[arg(long, default_value = "submission.yml")]
+        config: String,
+        
+        /// Competition ID (overrides config file)
         #[arg(long)]
-        api_key: String,
+        competition_id: Option<String>,
         
-        /// Base URL for the server (without trailing slash)
-        #[arg(long, default_value = "http://localhost:3000")]
-        server: String,
+        /// API key for authentication (overrides config file)
+        #[arg(long)]
+        api_key: Option<String>,
         
-        /// Compression level (0-9, where 0 is no compression and 9 is maximum compression)
-        #[arg(long, default_value_t = 6)]
-        compression: u8,
+        /// Base URL for the server (overrides config file)
+        #[arg(long)]
+        server: Option<String>,
         
-        /// Skip server check and force a specific format (repo or py)
+        /// Compression level (0-9, overrides config file)
+        #[arg(long)]
+        compression: Option<u8>,
+        
+        /// Skip server check and force a specific format (repo or py) (overrides config file)
         #[arg(long)]
         force_format: Option<String>,
+        
+        /// Auto-confirm submission without prompting (overrides config file)
+        #[arg(long)]
+        auto_confirm: bool,
+    },
+    
+    /// Initialize a new submission.yml configuration file
+    Init {
+        /// Path to create the submission.yml config file
+        #[arg(long, default_value = "submission.yml")]
+        config: String,
+        
+        /// API key for authentication
+        #[arg(long)]
+        api_key: Option<String>,
+        
+        /// Competition ID
+        #[arg(long)]
+        competition_id: Option<String>,
     },
 }
 
-/// Check with the server for format requirements
-fn check_with_server(server_url: &str, api_key: &str) -> Result<CheckResponse> {
-    let check_url = format!("{}/check", server_url);
+/// Load the configuration file or create a default one if it doesn't exist
+fn load_config(config_path: &str) -> Result<SubmissionConfig> {
+    let config_file = PathBuf::from(config_path);
+    
+    if !config_file.exists() {
+        return Err(anyhow::anyhow!(
+            "Configuration file '{}' not found. You can create one with `optimus init`.", 
+            config_path
+        ));
+    }
+    
+    // Read the config file
+    let file = File::open(config_file)?;
+    let config: SubmissionConfig = serde_yaml::from_reader(file)?;
+    
+    Ok(config)
+}
+
+/// Create a new configuration file
+fn create_config_file(config_path: &str, api_key: Option<String>, competition_id: Option<String>) -> Result<()> {
+    let config_file = PathBuf::from(config_path);
+    
+    if config_file.exists() {
+        let overwrite = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!("Config file '{}' already exists. Overwrite?", config_path))
+            .default(false)
+            .interact()?;
+        
+        if !overwrite {
+            println!("❌ Config creation aborted.");
+            return Ok(());
+        }
+    }
+    
+    // Create a default config
+    let config = SubmissionConfig {
+        api_key: api_key.unwrap_or_else(|| "your-api-key-here".to_string()),
+        competition_id,
+        format: None,
+        server_url: default_server_url(),
+        compression_level: default_compression_level(),
+        exclude: vec![
+            ".git".to_string(),
+            ".DS_Store".to_string(), 
+            "node_modules".to_string(),
+            "target".to_string(),
+            ".env".to_string(),
+            "venv".to_string(),
+        ],
+        preferences: Preferences {
+            auto_confirm: false,
+            save_history: true,
+        },
+    };
+    
+    // Write the config to file
+    let file = File::create(config_file)?;
+    serde_yaml::to_writer(file, &config)?;
+    
+    println!("✅ Created configuration file: {}", config_path);
+    println!("   Please edit it to set your API key and other preferences.");
+    
+    Ok(())
+}
+
+/// Check with the server for format requirements and remaining attempts
+fn check_with_server(server_url: &str, api_key: &str, competition_id: Option<&str>) -> Result<CheckResponse> {
+    let mut check_url = format!("{}/check", server_url);
+    
+    // Add competition_id query parameter if available
+    if let Some(comp_id) = competition_id {
+        check_url = format!("{}?competition={}", check_url, comp_id);
+    }
+    
     println!("🔍 Checking with server: {}", check_url);
     
     let client = Client::new();
@@ -68,6 +214,8 @@ fn check_with_server(server_url: &str, api_key: &str) -> Result<CheckResponse> {
     
     // Print information about the server response
     println!("✅ Server requires format: {}", check_response.required_format);
+    println!("🔢 Remaining submission attempts: {}", check_response.remaining_attempts);
+    
     if let Some(last_submission) = check_response.last_submission_by_user {
         let duration = SystemTime::now()
             .duration_since(UNIX_EPOCH + Duration::from_secs(last_submission))
@@ -83,8 +231,8 @@ fn check_with_server(server_url: &str, api_key: &str) -> Result<CheckResponse> {
     Ok(check_response)
 }
 
-/// Create a zip archive based on the specified format
-fn create_zip_archive(compression: u8, format: &str) -> Result<PathBuf> {
+/// Create a zip archive based on the specified format and exclusions
+fn create_zip_archive(compression: u8, format: &str, custom_exclusions: &[String]) -> Result<PathBuf> {
     let current_dir = env::current_dir()?;
     let dir_name = current_dir.file_name()
         .context("Failed to get directory name")?
@@ -108,13 +256,16 @@ fn create_zip_archive(compression: u8, format: &str) -> Result<PathBuf> {
     let mut zip = ZipWriter::new(file);
     
     // Common excluded directories and files
-    let excluded = vec![
-        ".git", 
-        ".DS_Store", 
-        "target",
-        "node_modules",
-        ".zip"
+    let mut excluded = vec![
+        ".git".to_string(), 
+        ".DS_Store".to_string(), 
+        "target".to_string(),
+        "node_modules".to_string(),
+        ".zip".to_string()
     ];
+    
+    // Add custom exclusions
+    excluded.extend(custom_exclusions.iter().cloned());
     
     // Build include pattern based on format
     let include_patterns: Vec<&str> = match format {
@@ -139,6 +290,11 @@ fn create_zip_archive(compression: u8, format: &str) -> Result<PathBuf> {
         
         // Skip excluded directories and files
         if excluded.iter().any(|e| path_str.contains(e)) {
+            continue;
+        }
+        
+        // Skip submission.yml
+        if path_str.ends_with("submission.yml") {
             continue;
         }
         
@@ -179,7 +335,7 @@ fn create_zip_archive(compression: u8, format: &str) -> Result<PathBuf> {
 }
 
 /// Send the zip file to the endpoint
-fn send_zip_to_endpoint(zip_path: &Path, api_key: &str, submit_url: &str) -> Result<()> {
+fn send_zip_to_endpoint(zip_path: &Path, api_key: &str, submit_url: &str, competition_id: Option<&str>) -> Result<()> {
     let file = File::open(zip_path)?;
     let mut zip_content = Vec::new();
     
@@ -194,10 +350,15 @@ fn send_zip_to_endpoint(zip_path: &Path, api_key: &str, submit_url: &str) -> Res
         .context("Failed to get zip file name")?
         .to_string_lossy();
     
-    let form = multipart::Form::new()
+    let mut form = multipart::Form::new()
         .part("file", multipart::Part::bytes(zip_content)
             .file_name(file_name.to_string())
             .mime_str("application/zip")?);
+    
+    // Add competition_id if available
+    if let Some(comp_id) = competition_id {
+        form = form.text("competition", comp_id.to_string());
+    }
     
     // Send the POST request with the API key in the header
     let client = Client::new();
@@ -228,29 +389,85 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     
     match &cli.command {
-        Commands::Send { api_key, server, compression, force_format } => {
-            // Determine the format to use - either from force_format or server check
+        Commands::Init { config, api_key, competition_id } => {
+            create_config_file(config, api_key.clone(), competition_id.clone())?;
+        },
+        
+        Commands::Send { 
+            config, 
+            competition_id, 
+            api_key, 
+            server,
+            compression, 
+            force_format,
+            auto_confirm
+        } => {
+            // Load the configuration
+            let mut config_data = load_config(config)?;
+            
+            // Override config with command line arguments if provided
+            if let Some(api) = api_key {
+                config_data.api_key = api.clone();
+            }
+            
+            let comp_id = competition_id.as_deref().or(config_data.competition_id.as_deref());
+            
+            let server_url = match server {
+                Some(s) => s.clone(),
+                None => config_data.server_url.clone(),
+            };
+            
+            let comp_level = compression.unwrap_or(config_data.compression_level);
+            
+            let auto_confirm_submission = *auto_confirm || config_data.preferences.auto_confirm;
+            
+            // Determine the format to use - either from force_format, config, or server check
             let format = if let Some(forced) = force_format {
                 println!("⚠️ Bypassing server check, using forced format: {}", forced);
-                forced.to_string()
+                forced.clone()
+            } else if let Some(config_format) = &config_data.format {
+                println!("⚠️ Using format from config file: {}", config_format);
+                config_format.clone()
             } else {
                 // Contact the server to check the required format
-                let check_response = check_with_server(server, api_key)?;
+                let check_response = check_with_server(&server_url, &config_data.api_key, comp_id)?;
+                
+                // Prompt the user for confirmation based on remaining attempts
+                if !auto_confirm_submission {
+                    let confirm_msg = format!(
+                        "You have {} submission attempts remaining. Proceed with submission?",
+                        check_response.remaining_attempts
+                    );
+                    
+                    let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+                        .with_prompt(confirm_msg)
+                        .default(true)
+                        .interact()?;
+                    
+                    if !confirmed {
+                        println!("❌ Submission cancelled.");
+                        return Ok(());
+                    }
+                }
+                
                 check_response.required_format
             };
             
             // Validate format is either "repo" or "py"
             if format != "repo" && format != "py" {
-                return Err(anyhow::anyhow!("Unsupported format from server: {}. Expected 'repo' or 'py'", format));
+                return Err(anyhow::anyhow!(
+                    "Unsupported format: {}. Expected 'repo' or 'py'", 
+                    format
+                ));
             }
             
             // Create zip archive based on the required format
-            let zip_path = create_zip_archive(*compression, &format)?;
+            let zip_path = create_zip_archive(comp_level, &format, &config_data.exclude)?;
             println!("✅ Created zip archive at: {}", zip_path.display());
             
             // Send the zip file to the submit endpoint
-            let submit_url = format!("{}/submit", server);
-            send_zip_to_endpoint(&zip_path, api_key, &submit_url)?;
+            let submit_url = format!("{}/submit", server_url);
+            send_zip_to_endpoint(&zip_path, &config_data.api_key, &submit_url, comp_id)?;
         }
     }
     

--- a/server-example/package.json
+++ b/server-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "optimus-server",
   "version": "1.0.0",
-  "description": "Server for receiving Optimus zip uploads",
+  "description": "Competition submission server for Optimus Prime with attempt tracking",
   "main": "server.js",
   "scripts": {
     "start": "node server.js"

--- a/submission.yml
+++ b/submission.yml
@@ -1,0 +1,33 @@
+# Example submission.yml configuration file for Optimus Prime
+
+# API key for authentication (required)
+api_key: "your-api-key-here"
+
+# Competition ID (optional, can be overridden via command line)
+competition_id: "competition-123"
+
+# Submission format: 'repo' or 'py' (optional, will check with server if not specified)
+format: "repo"
+
+# Server URL (optional, defaults to http://localhost:3000)
+server_url: "http://localhost:3000"
+
+# Compression level (0-9, optional, default is 6)
+compression_level: 6
+
+# Excluded directories/files (optional, adds to default exclusions)
+exclude:
+  - ".git"
+  - ".DS_Store"
+  - "node_modules"
+  - "target"
+  - ".env"
+  - "venv"
+
+# User preferences (optional)
+preferences:
+  # Whether to auto-confirm submissions (optional, default is false)
+  auto_confirm: false
+  
+  # Whether to save submission history (optional, default is true)
+  save_history: true

--- a/systemd/optimus-server.service
+++ b/systemd/optimus-server.service
@@ -13,5 +13,8 @@ Environment=PORT=3000
 Environment=API_KEY=your-api-key-goes-here
 Environment=DEFAULT_FORMAT=repo
 
+# Optional: Set default maximum attempts for competitions
+# Environment=MAX_ATTEMPTS=3
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hi @lwalker94!

This is a chunky commit, sorry, but I think it's good stuff!

So I created an init command to generate a yml file with descriptions of the submission, like the api key/user id, the competition id, if it's a repo or file submission, what environment manager it uses etc. 

Then when it runs against a /check end point it will pass the api key and competition id, which will check user submissions against a decrimenting counter in the back end, request permission and continue to push to /submit the bundled assets as either the whole repo or the necessary files to replicate it. 